### PR TITLE
Updated logging, initialization, and method functionality

### DIFF
--- a/RepairCafeCureApp/CAssetTab.cpp
+++ b/RepairCafeCureApp/CAssetTab.cpp
@@ -313,7 +313,13 @@ void CAssetTab::OnDoubleClickAssetTabAssetList(NMHDR* pNMHDR, LRESULT* pResult) 
 // After update the update asset button is disabled and the create workorder button is enabled.
 void CAssetTab::OnBnClickedAssetTabUpdate()
 {
+	UpdateData(TRUE);
 	CString strQuery;
+
+	auto strCurDate{ COleDateTime::GetCurrentTime().Format(_T("%m/%d/%Y")) };
+	if (!m_strHistoryLog.IsEmpty())
+		m_strHistoryLog = _T("\r\n");
+	m_strHistoryLog += _T("[") + strCurDate + _T(", ") + theApp.GetSelectedEmployeeName() + _T("] Asset details are updated.");
 
 	// Build the fields value for the query.
 	auto buildFieldValue = [](CString str) ->CString{
@@ -371,16 +377,19 @@ void CAssetTab::OnBnClickedAssetTabUpdate()
 	strQuery.ReleaseBuffer();
 	sql.CloseConnection();
 	theApp.EndWaitCursor();
+	UpdateData(FALSE);
 } 
 // OnBnClickedAssetTabNew is called when the user clicks on the new asset button.
 // a new asset is created in the database.
 // After creation the new asset button is disabled and the create workorder button is enabled.
 void CAssetTab::OnBnClickedAssetTabNew(){
-	// Creation date is the current date.
-	auto time = CTime().GetCurrentTime();
-	auto strDate = time.Format(_T("%m/%d/%Y"));
+	UpdateData(TRUE);
 
 	CString strQuery;
+	auto strCurDate{ COleDateTime::GetCurrentTime().Format(_T("%m/%d/%Y")) };
+	if (!m_strHistoryLog.IsEmpty())
+		m_strHistoryLog = _T("\r\n");
+	m_strHistoryLog += _T("[") + strCurDate + _T(", ") + theApp.GetSelectedEmployeeName() + _T("] Asset Created.");
 
 	// Build the fields value for the query.
 	auto buildFieldValue = [](CString str) -> CString{
@@ -393,7 +402,7 @@ void CAssetTab::OnBnClickedAssetTabNew(){
 	strQuery.Format(_T("INSERT INTO [ASSET] ([ASSET_CUSTOMER_ID], [ASSET_WORKORDER_ID], [ASSET_CREATE_DATE], [ASSET_DESCRIPTION], ")
 		_T("[ASSET_MODEL_NUMBER], [ASSET_BRAND], [ASSET_DISPOSED], [ASSET_HISTORY_LOG]) VALUES(% d, NULL, % s, % s, % s, % s, 0, NULL)"),
 		m_nAssetCustomerID,
-		buildFieldValue(strDate),
+		buildFieldValue(strCurDate),
 		buildFieldValue(m_strDescription),
 		buildFieldValue(m_strModelNumber),
 		buildFieldValue(m_strBrand));
@@ -428,6 +437,7 @@ void CAssetTab::OnBnClickedAssetTabNew(){
 	sql.CloseConnection();
 	theApp.EndWaitCursor();
 	m_bIsSelectedFromAssetList = true;
+	UpdateData(FALSE);
 }
 
 // OnBnClickedAssetTabCreateWorkorder is called when the user clicks on the create workorder button.

--- a/RepairCafeCureApp/CContributionPaymentDialog.h
+++ b/RepairCafeCureApp/CContributionPaymentDialog.h
@@ -58,9 +58,9 @@ namespace artvabas::rcc::ui::dialogs {
 	/* Data structures for value transfer between classes */
 	public:
 		struct InvoiceData {
-			unsigned int unCustomerID{};
-			unsigned int unAssetID{};
-			unsigned int unWorkOrderID{};
+			unsigned int unCustomerID;
+			unsigned int unAssetID;
+			unsigned int unWorkOrderID;
 			CString strTotal;
 		};
 

--- a/RepairCafeCureApp/CWorkorderTab.cpp
+++ b/RepairCafeCureApp/CWorkorderTab.cpp
@@ -168,6 +168,8 @@ void CWorkorderTab::OnBnClickedWoTabCreate()
 {
 	UpdateData(TRUE);
 	CString strQuery;
+	auto strCurDate{ COleDateTime::GetCurrentTime().Format(_T("%m/%d/%Y")) };
+	CString strWorkorderLog{ _T("[") + strCurDate + _T(", ") + theApp.GetSelectedEmployeeName() + _T("] Workorder Created.") };
 
 	// Build the fields value for the query.
 	auto buildFieldValue = [](CString str) -> CString {
@@ -179,12 +181,13 @@ void CWorkorderTab::OnBnClickedWoTabCreate()
 
 	strQuery.Format(_T("INSERT INTO [WORKORDER] ([WORKORDER_ASSET_ID], [WORKORDER_CUSTOMER_ID], [WORKORDER_INVOICE_ID], ")
 		_T("[WORKORDER_CREATE_DATE], [WORKORDER_CREATE_BY], [WORKORDER_DESCRIPTION], [WORKORDER_RESPONSIBLE], [WORKORDER_STATUS], ")
-		_T("[WORKORDER_LOG], [WORKORDER_HISTORY]) VALUES(% d, % d, NULL, % s, % s, % s, NULL, % s, NULL, NULL)"),
+		_T("[WORKORDER_LOG], [WORKORDER_HISTORY]) VALUES(%d, %d, NULL, %s, %s, %s, NULL, %s, NULL, %s)"),
 		m_uiAssetID, m_uiCustomerID,
 		buildFieldValue(COleDateTime::GetCurrentTime().Format(_T("%m/%d/%Y"))),
 		buildFieldValue(theApp.GetSelectedEmployeeName()),
 		buildFieldValue(m_strWorkorderDescription),
-		buildFieldValue(_T("Open")));
+		buildFieldValue(_T("Open")),
+		buildFieldValue(strWorkorderLog));
 
 	theApp.SetStatusBarText(IDS_STATUSBAR_LOADING);
 	theApp.BeginWaitCursor();

--- a/RepairCafeCureApp/MainFrm.cpp
+++ b/RepairCafeCureApp/MainFrm.cpp
@@ -67,6 +67,7 @@ CMainFrame::CMainFrame() noexcept
 
 CMainFrame::~CMainFrame()
 {
+	m_wndRibbonBar.HideAllContextCategories();
 	if ( m_pCmbCaptionBarEmployeeName != nullptr ) {
 		delete m_pCmbCaptionBarEmployeeName;
 		m_pCmbCaptionBarEmployeeName = nullptr;
@@ -183,7 +184,7 @@ void CMainFrame::OnFilePrintPreview()
 	if ( IsPrintPreview() ) PostMessage(WM_COMMAND, AFX_ID_PREVIEW_CLOSE);
 }
 
-// OnCaptionBarComboBoxEmployeeNameChange is called when the user selects an employee name from the combobox
+// OnCaptionBarComboBoxEmployeeNameChange is called when the user selects an employee name from the combo box
 void CMainFrame::OnCaptionBarComboBoxEmployeeNameChange()
 {
 	if ( m_pCmbCaptionBarEmployeeName == nullptr ) return;
@@ -208,7 +209,7 @@ void CMainFrame::OnCaptionBarComboBoxEmployeeNameChange()
 /* Member methods*/
 
 // CreateCaptionBar is called to create the caption bar
-// It is used to create the caption bar and the combobox for the employee names
+// It is used to create the caption bar and the combo box for the employee names
 BOOL CMainFrame::CreateCaptionBar()
 {
 	if ( !m_wndCaptionBar.Create(WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS, this, ID_VIEW_CAPTION_BAR, -1, TRUE) ) {
@@ -231,7 +232,7 @@ BOOL CMainFrame::CreateCaptionBar()
 	ASSERT(bNameValid);
 	m_wndCaptionBar.SetImageToolTip(strTemp, strTemp2);
 
-	// Combobox for employee names
+	// Combo box for employee names
 	m_pCmbCaptionBarEmployeeName->Create(WS_CHILD | WS_VISIBLE | EBS_READONLY | CBS_DROPDOWN, CRect(350, 6, 550, 100), &m_wndCaptionBar,
 		IDC_CAPTION_COMBOBOX_EMPLOYEE_NAME);
 
@@ -283,7 +284,7 @@ BOOL CMainFrame::CreateCaptionBar()
 	return TRUE;
 }
 
-// GetSelectedEmployee is called to get the selected employee name from the combobox
+// GetSelectedEmployee is called to get the selected employee name from the combo box
 CString CMainFrame::GetSelectedEmployee() {
 	CString strEmployee;
 	auto nIndex = m_pCmbCaptionBarEmployeeName->GetCurSel();

--- a/RepairCafeCureApp/RepairCafeCureApp.cpp
+++ b/RepairCafeCureApp/RepairCafeCureApp.cpp
@@ -76,7 +76,7 @@ static void __stdcall TimerCallback(HWND hwnd, UINT uMsg, UINT_PTR idEvent, DWOR
 	auto dwTimeNow = GetTickCount64();
 	auto dwTimeIdle = dwTimeNow - lii.dwTime;
 
-	if ( dwTimeIdle > 1000 * 60 * 1 && !isIdle ) {
+	if (dwTimeIdle > static_cast<unsigned long long>(1000 * 60) * 1 && !isIdle) {
 		theApp.IsIdle();
 		isIdle = true;
 		auto result = MessageBoxW(NULL, _T("Automatically Locked the app!"), _T("Idle"), MB_OK);
@@ -99,13 +99,13 @@ CRepairCafeCureApp::CRepairCafeCureApp() noexcept
 
 CRepairCafeCureApp::~CRepairCafeCureApp()
 {
+	KillTimer(NULL, 1);
+	m_SplashScreen.DestroyWindow();
 	if ( NULL != m_dbConnection )
 	{
 		delete m_dbConnection;
 		m_dbConnection = NULL;
 	}
-	m_SplashScreen.DestroyWindow();
-	KillTimer(NULL, 1);
 }
 
 /* Message handles bindings */
@@ -125,6 +125,15 @@ END_MESSAGE_MAP()
 BOOL CRepairCafeCureApp::InitInstance()
 {
 	CWinAppEx::InitInstance();
+
+	// Initialize OLE libraries
+	if (!AfxOleInit())
+	{
+		AfxMessageBox(IDP_OLE_INIT_FAILED);
+		return FALSE;
+	}
+
+	EnableTaskbarInteraction(FALSE);
 
 	m_SplashScreen.Create(IDD_SPLASHSCREEN);
 
@@ -158,7 +167,7 @@ BOOL CRepairCafeCureApp::InitInstance()
 	ParseCommandLine(cmdInfo);
 
 	// Dispatch commands specified on the command line.  Will return FALSE if
-	// app was launched with /RegServer, /Register, /Unregserver or /Unregister.
+	// app was launched with /RegServer, /Register, /Un-regserver or /Unregister.
 	if (!ProcessShellCommand(cmdInfo))
 		return FALSE;
 
@@ -213,7 +222,7 @@ BOOL CRepairCafeCureApp::InitInstance()
 int CRepairCafeCureApp::ExitInstance()
 {
 	//TODO: handle additional resources you may have added
-	AfxOleTerm(FALSE);
+	//AfxOleTerm(FALSE);
 	
 	return CWinAppEx::ExitInstance();
 }
@@ -325,7 +334,7 @@ CView* CRepairCafeCureApp::SwitchView(ViewType vtView)
 }
 
 // SetStatusBarText is used to set the status bar text
-// - nstrID, the ID from string table
+// - nStrID, the ID from string table
 void CRepairCafeCureApp::SetStatusBarText(UINT nStrID)
 {
 	BOOL bNameValid;


### PR DESCRIPTION
Updated various methods in `CAssetTab.cpp`, `CContributionPaymentDialog.h`, `CWorkorderTab.cpp`, `CWorkorderView.cpp`, `MainFrm.cpp`, and `RepairCafeCureApp.cpp`.

The updates include adding a history log of asset updates and creations in `CAssetTab.cpp`, removing default initialization of members in `CContributionPaymentDialog.h`, including a log of work order creations in `CWorkorderTab.cpp`, and updating the functionality of several methods in `CWorkorderView.cpp`.

In `MainFrm.cpp` and `RepairCafeCureApp.cpp`, comments about method functionality have been corrected. Also, `CRepairCafeCureApp::InitInstance` now initializes OLE libraries and disables taskbar interaction, and `CRepairCafeCureApp::ExitInstance` has a commented out call to `AfxOleTerm(FALSE)`.