### PR TITLE
Updated control flow and UI interactions in CWorkorderPartsDialog

### DIFF
--- a/RepairCafeCureApp/CAssetTab.cpp
+++ b/RepairCafeCureApp/CAssetTab.cpp
@@ -231,6 +231,8 @@ BOOL CAssetTab::PreTranslateMessage(MSG* pMsg)
 					OnBnClickedAssetTabNew();
 					return TRUE;
 				}
+			} else {
+				return CDialogEx::PreTranslateMessage(pMsg);
 			}
 		}
 	}

--- a/RepairCafeCureApp/CContributionPaymentDialog.cpp
+++ b/RepairCafeCureApp/CContributionPaymentDialog.cpp
@@ -99,6 +99,8 @@ BOOL CContributionPaymentDialog::PreTranslateMessage(MSG* pMsg)
 				}
 				return TRUE;
 			}
+		} else {
+			return CDialogEx::PreTranslateMessage(pMsg);
 		}
 	}
 	return FALSE;

--- a/RepairCafeCureApp/CWorkorderPartsDialog.h
+++ b/RepairCafeCureApp/CWorkorderPartsDialog.h
@@ -64,15 +64,16 @@ namespace artvabas::rcc::ui::dialogs {
 		CString m_strWorkorderPartUnitPrice;
 		CString m_strWorkorderPartTotalPrice;
 
-		CButton m_btnWorkorderPartAdd;
-		CButton m_btnWorkorderPartDelete;
-		CButton m_btnWorkorderPartChange;
+		CMFCButton m_btnWorkorderPartAdd;
+		CMFCButton m_btnWorkorderPartDelete;
+		CMFCButton m_btnWorkorderPartChange;
 
 	public:
 		CWorkorderPartsDialog(const unsigned int& nWorkorderID, CWnd* pParent = nullptr) noexcept;
 		virtual ~CWorkorderPartsDialog();
 
 	private:
+		BOOL PreTranslateMessage(MSG* pMsg) override;
 		void DoDataExchange(CDataExchange* pDX) override;
 		BOOL OnInitDialog() override;
 		void OnOK() override;
@@ -94,5 +95,6 @@ namespace artvabas::rcc::ui::dialogs {
 		void CalculateTotalPrice() noexcept;
 		void SetChangeDeleteButtonState(BOOL bFlag = TRUE) noexcept;
 		void ClearPartInputFields() noexcept;
+		void SetCustomFocusButton(CMFCButton* pButton, ColorButton Color, bool bFocus) noexcept;
 	};
 }

--- a/RepairCafeCureApp/CWorkorderTab.cpp
+++ b/RepairCafeCureApp/CWorkorderTab.cpp
@@ -140,6 +140,8 @@ BOOL CWorkorderTab::PreTranslateMessage(MSG* pMsg) {
 					OnBnClickedWoTabCreate();
 					return TRUE;
 				}
+			} else {
+				return CDialogEx::PreTranslateMessage(pMsg);
 			}
 		}
 	}

--- a/RepairCafeCureApp/CWorkorderView.cpp
+++ b/RepairCafeCureApp/CWorkorderView.cpp
@@ -461,6 +461,7 @@ void CWorkorderView::OnNMDoubleClickWorkorderViewExisting(NMHDR* pNMHDR, LRESULT
 				m_chbWorkorderContactedCustomer.EnableWindow(TRUE);
 				m_btnWorkorderUpdate.EnableWindow(FALSE);
 				m_btnWorkorderClose.EnableWindow(TRUE);
+				SetCustomFocusButton(&m_btnWorkorderClose, ColorButton::RED, true);
 				m_cbxWorkorderEmployeeResponsible.EnableWindow(FALSE);
 				m_bResponsibleChanged = false;
 				ribbonBar->ShowContextCategories(ID_CONTEXT_WORKORDER);


### PR DESCRIPTION
This commit includes several updates to the control flow and user interface interactions in the `CWorkorderPartsDialog` class. The `PreTranslateMessage` function has been updated in several files to return `CDialogEx::PreTranslateMessage(pMsg)` when the `if` condition is not met. A new `PreTranslateMessage` function has been added to `CWorkorderPartsDialog.cpp` to handle `WM_KEYDOWN` messages. The `OnInitDialog`, `OnEnChangeWorkorderAddParts`, `OnNMDoubleClickWorkorderStockPartsList`, `OnNMClickWorkorderAddedPartsList`, `OnBnClickedWorkorderAddPart`, `OnBnClickedWorkorderChange`, and `OnBnClickedWorkorderDeleteAddedPart` functions have been updated to improve focus management and button interaction. A new `SetCustomFocusButton` function has been added to set the text color and focus of a button. The `CWorkorderPartsDialog` class has been updated to change the type of several button members from `CButton` to `CMFCButton` and add the `PreTranslateMessage` function to the class declaration. The `OnNMDoubleClickWorkorderViewExisting` function in `CWorkorderView.cpp` has been updated to call the `SetCustomFocusButton` function.