### PR TITLE
TEST: Switched print command in SendMessage function

### DIFF
--- a/RepairCafeCureApp/CWorkorderView.cpp
+++ b/RepairCafeCureApp/CWorkorderView.cpp
@@ -688,7 +688,7 @@ void CWorkorderView::OnBnClickedWorkorderViewParts() noexcept
 void CWorkorderView::OnWorkorderExtraCombi() noexcept
 {
 	m_bPrintCombi = true;
-	this->SendMessage(WM_COMMAND, ID_FILE_PRINT_DIRECT);
+	this->SendMessage(WM_COMMAND, ID_FILE_PRINT);
 }
 
 // OnWorkorderExtraInvoice is called by the framework when the user clicks on the invoice button.


### PR DESCRIPTION
Modified the `SendMessage` function call in the `OnWorkorderExtraCombi` method of the `CWorkorderView` class. The function now sends the `WM_COMMAND` message with `ID_FILE_PRINT` as the command parameter instead of `ID_FILE_PRINT_DIRECT`. This change switches the print operation from a direct print command to a standard print command, which typically opens a print dialog before proceeding with the print operation.