### PR TITLE
Enhanced workorder reporting and details

### DIFF
--- a/RepairCafeCureApp/CClosedWorkorderDetailsTabCtrl.cpp
+++ b/RepairCafeCureApp/CClosedWorkorderDetailsTabCtrl.cpp
@@ -1,0 +1,30 @@
+// CClosedWorkorderDetailsTabCtrl.cpp : implementation file
+//
+
+#include "pch.h"
+#include "RepairCafeCureApp.h"
+#include "CClosedWorkorderDetailsTabCtrl.h"
+
+
+// CClosedWorkorderDetailsTabCtrl
+
+IMPLEMENT_DYNAMIC(CClosedWorkorderDetailsTabCtrl, CTabCtrl)
+
+CClosedWorkorderDetailsTabCtrl::CClosedWorkorderDetailsTabCtrl()
+{
+
+}
+
+CClosedWorkorderDetailsTabCtrl::~CClosedWorkorderDetailsTabCtrl()
+{
+}
+
+
+BEGIN_MESSAGE_MAP(CClosedWorkorderDetailsTabCtrl, CTabCtrl)
+END_MESSAGE_MAP()
+
+
+
+// CClosedWorkorderDetailsTabCtrl message handlers
+
+

--- a/RepairCafeCureApp/CClosedWorkorderDetailsTabCtrl.h
+++ b/RepairCafeCureApp/CClosedWorkorderDetailsTabCtrl.h
@@ -1,0 +1,18 @@
+#pragma once
+
+
+// CClosedWorkorderDetailsTabCtrl
+
+class CClosedWorkorderDetailsTabCtrl : public CTabCtrl
+{
+	DECLARE_DYNAMIC(CClosedWorkorderDetailsTabCtrl)
+
+public:
+	CClosedWorkorderDetailsTabCtrl();
+	virtual ~CClosedWorkorderDetailsTabCtrl();
+
+protected:
+	DECLARE_MESSAGE_MAP()
+};
+
+

--- a/RepairCafeCureApp/CPrintWorkorder.cpp
+++ b/RepairCafeCureApp/CPrintWorkorder.cpp
@@ -676,6 +676,8 @@ void CPrintWorkorder::PrintInvoice(CDC* pDC) const noexcept
 	pDC->DrawText(_T("Totaal:"), rctTotal, DT_RIGHT | DT_TABSTOP);
 	pDC->DrawText(_T("€") + m_pStructWorkorderData->strWorkorderTotalPartsPrice, rctTotalAmount, DT_RIGHT | DT_TABSTOP);
 
+	pDC->TextOutW(nPosX, nPosY += BodyTextLineDown(2), _T("• Administratie kosten: Bankkosten t.b.v. uw bestelde onderdeel(en)."));
+
 	// Destroy image
 	imgLogo.Destroy();
 	fontPlainHeader.DeleteObject();

--- a/RepairCafeCureApp/CReportWorkorderClosedView.h
+++ b/RepairCafeCureApp/CReportWorkorderClosedView.h
@@ -79,6 +79,7 @@ private:
 private:
 	DECLARE_MESSAGE_MAP()
 	afx_msg void OnFilePrintPreview() noexcept;
+	afx_msg void OnShowWindow(BOOL bShow, UINT nStatus);
 	afx_msg void OnNMDoubleClickWorkorderClosedReport(NMHDR* pNMHDR, LRESULT* pResult) noexcept;
 
 public:

--- a/RepairCafeCureApp/DatabaseTables.h
+++ b/RepairCafeCureApp/DatabaseTables.h
@@ -34,9 +34,9 @@
 * It is used to avoid hardcoding the SQL column indexes in the project
 *
 * Target: Windows 10/11 64bit
-* Version: 0.0.1.0 (Alpha)
+* Version: 1.0.0.1 (Alpha)
 * Created: 25-04-2024, (dd-mm-yyyy)
-* Updated: 28-04-2024, (dd-mm-yyyy)
+* Updated: 12-06-2024, (dd-mm-yyyy)
 * Creator: artvabasDev / artvabas
 *
 * License: GPLv3
@@ -131,5 +131,19 @@ namespace artvabas::database::tables {
 			SQLSMALLINT CUSTOMER_CELL_PHONE{ 5 };
 			SQLSMALLINT CONTRIBUTION_AMOUNT{ 6 };
 		}REPORT_CONTRIBUTION_TAX;
+	}
+
+	namespace closedworkorders {
+		constexpr struct closedworkorders {
+			SQLUSMALLINT WORKORDER_ID{ 1 };
+			SQLUSMALLINT WORKORDER_DESCRIPTION{ 2 };
+			SQLUSMALLINT WORKORDER_RESPONSIBLE{ 3 };
+			SQLUSMALLINT WORKORDER_CLOSED_DATE{ 4 };
+			SQLUSMALLINT WORKORDER_STATUS{ 5 };
+			SQLUSMALLINT WORKORDER_ASSET_ID{ 6 };
+			SQLUSMALLINT ASSET_DESCRIPTION{ 7 };
+			SQLUSMALLINT WORKORDER_CUSTOMER_ID{ 8 };
+			SQLUSMALLINT WORKORDER_INVOICE_ID{ 9 };
+		}CLOSED_WORKORDERS;
 	}
 }

--- a/RepairCafeCureApp/RepairCafeCureApp.vcxproj
+++ b/RepairCafeCureApp/RepairCafeCureApp.vcxproj
@@ -193,6 +193,7 @@
   <ItemGroup>
     <ClInclude Include="CAssetDialog.h" />
     <ClInclude Include="CAssetTab.h" />
+    <ClInclude Include="CClosedWorkorderDetailsTabCtrl.h" />
     <ClInclude Include="CContributionPaymentDialog.h" />
     <ClInclude Include="CCustomerView.h" />
     <ClInclude Include="CDatabaseConnection.h" />
@@ -219,6 +220,7 @@
   <ItemGroup>
     <ClCompile Include="CAssetDialog.cpp" />
     <ClCompile Include="CAssetTab.cpp" />
+    <ClCompile Include="CClosedWorkorderDetailsTabCtrl.cpp" />
     <ClCompile Include="CContributionPaymentDialog.cpp" />
     <ClCompile Include="CCustomerView.cpp" />
     <ClCompile Include="CDatabaseConnection.cpp" />

--- a/RepairCafeCureApp/RepairCafeCureApp.vcxproj.filters
+++ b/RepairCafeCureApp/RepairCafeCureApp.vcxproj.filters
@@ -153,6 +153,9 @@
     <ClInclude Include="CReportWorkorderClosedView.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="CClosedWorkorderDetailsTabCtrl.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="RepairCafeCureApp.cpp">
@@ -210,6 +213,9 @@
       <Filter>Source Files\artvabas\rcc\ui</Filter>
     </ClCompile>
     <ClCompile Include="CReportWorkorderClosedView.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="CClosedWorkorderDetailsTabCtrl.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
- In CPrintWorkorder.cpp, added functionality to print bank charge-related administration costs in the PrintInvoice function and corrected the function's closing brace.
- Updated CReportWorkorderClosedView.cpp and .h to include new headers for SQL and database table usage, utilize specific namespaces for cleaner code, add a message handler for WM_SHOWWINDOW to load and display closed workorders, correct a column name in the list control setup, and implement fetching and displaying closed workorders data from the database.
- Enhanced DatabaseTables.h with a new version, updated date, and a new namespace with a struct for closed workorders SQL column indices.
- Adjusted the project files to add CClosedWorkorderDetailsTabCtrl.h and .cpp, ensuring proper compilation and organization within the project.
- Introduced new files CClosedWorkorderDetailsTabCtrl.cpp and .h for managing tab controls for closed workorder details, following standard MFC class structure.